### PR TITLE
perf/refactor(client): cache skin to avoid server callbacks + replace k, v loops with numeric for loops

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -104,7 +104,7 @@ end)
 -- Create Blips
 CreateThread(function()
 	for i = 1, #Config.Shops do
-      		local blip = AddBlipForCoord(v)
+      		local blip = AddBlipForCoord(Config.Shops[i])
 
 		SetBlipSprite (blip, 71)
 		SetBlipColour (blip, 51)

--- a/client/main.lua
+++ b/client/main.lua
@@ -123,7 +123,7 @@ CreateThread(function()
 		local playerCoords, isInMarker, currentZone, letSleep = GetEntityCoords(PlayerPedId()), nil, nil, true
 
 		for y = 1, #Config.Shops do
-			local distance = #(playerCoords - v)
+			local distance = #(playerCoords - Config.Shops[y])
 
 			if distance < Config.DrawDistance then
 				letSleep = false

--- a/client/main.lua
+++ b/client/main.lua
@@ -103,8 +103,8 @@ end)
 
 -- Create Blips
 CreateThread(function()
-	for k,v in ipairs(Config.Shops) do
-		local blip = AddBlipForCoord(v)
+	for i = 1, #Config.Shops do
+      		local blip = AddBlipForCoord(v)
 
 		SetBlipSprite (blip, 71)
 		SetBlipColour (blip, 51)
@@ -113,7 +113,7 @@ CreateThread(function()
 		BeginTextCommandSetBlipName('STRING')
 		AddTextComponentSubstringPlayerName(TranslateCap('barber_blip'))
 		EndTextCommandSetBlipName(blip)
-	end
+    	end
 end)
 
 -- Enter / Exit marker events and draw marker
@@ -122,7 +122,7 @@ CreateThread(function()
 		Wait(0)
 		local playerCoords, isInMarker, currentZone, letSleep = GetEntityCoords(PlayerPedId()), nil, nil, true
 
-		for k,v in ipairs(Config.Shops) do
+		for y = 1, #Config.Shops do
 			local distance = #(playerCoords - v)
 
 			if distance < Config.DrawDistance then

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,8 +1,16 @@
-local hasAlreadyEnteredMarker, lastZone, currentAction, currentActionMsg, hasPaid
+local hasAlreadyEnteredMarker, cachedSkin, lastZone, currentAction, currentActionMsg, hasPaid
 
 function OpenShopMenu()
 	ESX.HideUI()
 	hasPaid = false
+
+	TriggerEvent('skinchanger:getSkin', function(skin)
+		cachedSkin = skin;
+	end)
+
+	while not cachedSkin do
+		Wait(10)
+	end
 
 	TriggerEvent('esx_skin:openRestrictedMenu', function(data, menu)
 		menu.close()
@@ -26,17 +34,13 @@ function OpenShopMenu()
 						hasPaid = true
 					else
 						ESX.CloseContext()
-						ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin)
-							TriggerEvent('skinchanger:loadSkin', skin) 
-						end)
-
+						TriggerEvent('skinchanger:loadSkin', cachedSkin)
+									
 						ESX.ShowNotification(TranslateCap('not_enough_money'))
 					end
 				end)
 			elseif element.value == "no" then
-				ESX.TriggerServerCallback('esx_skin:getPlayerSkin', function(skin)
-					TriggerEvent('skinchanger:loadSkin', skin) 
-				end)
+				TriggerEvent('skinchanger:loadSkin', cachedSkin) 
 				ESX.CloseContext()
 			end
 			currentAction = 'shop_menu'


### PR DESCRIPTION
I just came across this code, i was bored and I thought that I could also contribute something small to the project.

Commit 37016689d5abd56f73f5828355181f42bef97a04

I was wondering why whenever the skin, before entering the shop has to be reloaded, a server callback is made to load the skin. Thats unnecessary, now the skin gets cached before the menu opens and gets loaded from the cache whenever needed.

```
while not currentSkin do
    Wait(10)
end
```
This just makes sure that the event callback has already returned the current skin and loaded it into the cache.

Commit 6b35a88a5313360b252ed04cd4fdc1795ee39c2c

I just replaced the two for ` k, v ipairs` loops with numeric for loops to increase performance a bit